### PR TITLE
Allow specification of a reference snapshot with metadata for all particle types

### DIFF
--- a/chunk_tasks.py
+++ b/chunk_tasks.py
@@ -181,11 +181,6 @@ class ChunkTask:
             properties = None
         properties = comm.bcast(properties)
 
-        # Don't try to read particle types which don't exist in the snapshot
-        for ptype in list(properties.keys()):
-            if ptype not in cellgrid.ptypes:
-                del properties[ptype]
-
         # Read in particles in the required region
         comm.barrier()
         t0_read = time.time()

--- a/command_line_args.py
+++ b/command_line_args.py
@@ -25,15 +25,15 @@ def get_halo_props_args(comm):
 
         parser = ThrowingArgumentParser(description='Compute halo properties in SWIFT snapshots.')
         parser.add_argument('swift_filename',
-                            help='Format string to generate snapshot filenames. Use %%(file_nr)d for the file number.')
+                            help='Format string to generate snapshot filenames. Use %%(file_nr)d for the file number and %%(snap_nr)04d for the snapshot.')
         parser.add_argument('vr_basename',
-                            help='Base name of the VELOCIraptor files, excluding trailing .properties[.N] etc.')
-        parser.add_argument('output_file', help='Name of the output file')
-        parser.add_argument("--chunks-per-dimension", metavar="N", nargs=1, type=int, default=1,
+                            help='Format string to generate base name of the VELOCIraptor files, excluding trailing .properties[.N] etc. Use %%(snap_nr)04d for the snapshot.')
+        parser.add_argument('output_file', help='Format string to generate name of the output file. Use %%(snap_nr)04d for the snapshot.')
+        parser.add_argument('snapshot_nr', help='Snapshot number to process', type=int)
+        parser.add_argument("--chunks-per-dimension", metavar="N", type=int, default=1,
                             help="Splits volume in N**3 chunks and each compute node processes one chunk at a time")
         parser.add_argument("--extra-input", metavar="FORMAT_STRING",
-                            help="Format string to generate names of files with additional particle datasets (e.g. halo membership)")
-
+                            help="Format string to generate names of files with additional particle datasets (e.g. halo membership). Use %%(file_nr)d for the file number and %%(snap_nr)04d for the snapshot.")
         parser.add_argument("--centrals-only", action="store_true", help="Only process central halos")
         parser.add_argument("--max-halos", metavar="N", nargs=1, type=int, default=(0,),
                             help="(For debugging) only process the first N halos in the catalogue")

--- a/command_line_args.py
+++ b/command_line_args.py
@@ -38,7 +38,7 @@ def get_halo_props_args(comm):
         parser.add_argument("--max-halos", metavar="N", nargs=1, type=int, default=(0,),
                             help="(For debugging) only process the first N halos in the catalogue")
         parser.add_argument("--calculations", nargs="*", help="Which calculations to do (default is to do all)")
-
+        parser.add_argument("--reference-snapshot", help="Specify reference snapshot number containing all particle types", metavar="N", type=int)
         try:
             args = parser.parse_args()
         except ArgumentParserError as e:

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -72,7 +72,13 @@ if __name__ == "__main__":
     if comm_world_rank == 0:
         swift_filename = sub_snapnum(args.swift_filename, args.snapshot_nr)
         extra_input    = sub_snapnum(args.extra_input, args.snapshot_nr)
-        cellgrid = swift_cells.SWIFTCellGrid(swift_filename, extra_input)
+        if args.reference_snapshot is not None:
+            swift_filename_ref = sub_snapnum(args.swift_filename, args.reference_snapshot)
+            extra_input_ref    = sub_snapnum(args.extra_input, args.reference_snapshot)
+        else:
+            swift_filename_ref = None
+            extra_input_ref = None
+        cellgrid = swift_cells.SWIFTCellGrid(swift_filename, extra_input, swift_filename_ref, extra_input_ref)
         parsec_cgs = cellgrid.constants["parsec"]
         solar_mass_cgs = cellgrid.constants["solar_mass"]
         a = cellgrid.a

--- a/compute_halo_properties.py
+++ b/compute_halo_properties.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     # Get the full list of property calculations we can do
     halo_prop_list = [
         halo_properties.SOMasses(cellgrid),
-        halo_properties.CentreOfMass(cellgrid),
+        halo_properties.SubhaloBoundMasses(cellgrid),
     ]
     
     # Determine which calculations we're doing this time

--- a/halo_properties.py
+++ b/halo_properties.py
@@ -208,3 +208,9 @@ class SubhaloBoundMasses(HaloProperty):
             halo_result["CentreOfMassVelocity_"+ptype] = (cofm_vel[ptype],    "Centre of mass velocity of particles of type "+ptype)
         halo_result["StellarInitialMass"]              = (total_initial_mass, "Total initial mass of star particles")
         halo_result["BHSubgridMass"]                   = (total_subgrid_mass, "Total subgrid mass of black hole particles")
+
+        # Find total masses and particle numbers
+        halo_result["Mass_All"]    = np.sum(unyt.unyt_array([total_mass[ptype] for ptype in data]))
+        halo_result["NumPart_All"] = np.sum(unyt.unyt_array([nr_part[ptype] for ptype in data]))
+    
+        

--- a/scripts/FLAMINGO/L1000N1800/halo_properties_L1000N1800.sh
+++ b/scripts/FLAMINGO/L1000N1800/halo_properties_L1000N1800.sh
@@ -21,9 +21,6 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
-# Which snapshot to do
-snapnum=`printf '%04d' ${SLURM_ARRAY_TASK_ID}`
-
 # Which simulation to do
 sim="L1000N1800/${SLURM_JOB_NAME}"
 
@@ -34,10 +31,10 @@ basedir="/cosma8/data/dp004/flamingo/Runs/L1000N1800/${sim}/"
 outbase="/cosma8/data/dp004/jch/FLAMINGO/ScienceRuns/${sim}/"
 
 # Generate file names for this snapshot
-swift_filename="${basedir}/snapshots/flamingo_${snapnum}/flamingo_${snapnum}.%(file_nr)d.hdf5"
-extra_filename="${outbase}/group_membership/vr_membership_${snapnum}.%(file_nr)d.hdf5"
-vr_basename="${basedir}/VR/catalogue_${snapnum}/vr_catalogue_${snapnum}"
-outfile="${outbase}/${sim}/halo_properties/halo_properties_${snapnum}.hdf5"
+swift_filename="${basedir}/snapshots/flamingo_%(snap_nr)04d/flamingo_%(snap_nr)04d.%(file_nr)d.hdf5"
+extra_filename="${outbase}/group_membership/vr_membership_%(snap_nr)04d.%(file_nr)d.hdf5"
+vr_basename="${basedir}/VR/catalogue_%(snap_nr)04d/vr_catalogue_%(snap_nr)04d"
+outfile="${outbase}/${sim}/halo_properties/halo_properties_%(snap_nr)04d.hdf5"
 
 chunks_per_dimension=2
 
@@ -46,6 +43,6 @@ outdir=`dirname "${outfile}"`
 mkdir -p "${outdir}"
 
 mpirun python3 -u -m mpi4py ./compute_halo_properties.py \
-    ${swift_filename} ${vr_basename} ${outfile} \
+    ${swift_filename} ${vr_basename} ${outfile} ${SLURM_ARRAY_TASK_ID} \
     --chunks-per-dimension=${chunks_per_dimension} \
     --extra-input=${extra_filename}

--- a/scripts/test_halo_properties.sh
+++ b/scripts/test_halo_properties.sh
@@ -13,17 +13,15 @@
 module purge
 module load gnu_comp/11.1.0 openmpi/4.1.1 python/3.10.1
 
-snapnum=`printf '%04d' ${SLURM_ARRAY_TASK_ID}`
-
 basedir="/cosma5/data/jch/HaloProperties/200_w_lightcone/"
 
-swift_filename="${basedir}/snapshots/flamingo_${snapnum}.hdf5"
-vr_basename="${basedir}/vr/catalogue_${snapnum}/vr_catalogue_${snapnum}"
+swift_filename="${basedir}/snapshots/flamingo_%(snap_nr)04d.hdf5"
+vr_basename="${basedir}/vr/catalogue_%(snap_nr)04d/vr_catalogue_%(snap_nr)04d"
 chunks_per_dimension=1
-outfile="${basedir}/halo_properties/halo_properties_${snapnum}.hdf5"
-extra_filename="${basedir}/group_membership/vr_membership_${snapnum}.hdf5"
+outfile="${basedir}/halo_properties/halo_properties_%(snap_nr)04d.hdf5"
+extra_filename="${basedir}/group_membership/vr_membership_%(snap_nr)04d.hdf5"
 
 mpirun python3 -u -m mpi4py \
-    ./compute_halo_properties.py ${swift_filename} ${vr_basename} ${outfile} \
+    ./compute_halo_properties.py ${swift_filename} ${vr_basename} ${outfile} ${SLURM_ARRAY_TASK_ID} \
     --chunks-per-dimension=${chunks_per_dimension} \
     --extra-input=${extra_filename}


### PR DESCRIPTION
This is to allow the code to generate empty arrays with suitable data types and units in snapshots where there happen to be no particles of some type (e.g. stars or black holes at high redshift).
